### PR TITLE
don't specify a hard dependency on hiredis, since that should be opt-in

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 redis>=2.4.9
-hiredis


### PR DESCRIPTION
I normally like to leave "upgrades" like hiredis up to the application. I don't know if that makes sense in python, but I was wrestling with hiredis earlier thought this might be appropriate.
